### PR TITLE
Added templates to add default method to interface

### DIFF
--- a/api.mustache
+++ b/api.mustache
@@ -1,0 +1,35 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.spi.NotImplementedYetException;
+
+{{#useSwaggerAnnotations}}
+    import io.swagger.annotations.*;
+{{/useSwaggerAnnotations}}
+{{#supportAsync}}
+    import java.util.concurrent.CompletionStage;
+    import java.util.concurrent.CompletableFuture;
+{{/supportAsync}}
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.List;
+{{#useBeanValidation}}import javax.validation.constraints.*;
+import javax.validation.Valid;{{/useBeanValidation}}
+
+@Path("{{commonPath}}"){{#useSwaggerAnnotations}}
+    @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}
+    @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
+    @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
+{{>generatedAnnotation}}public {{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
+{{#operations}}
+    {{#operation}}
+
+        {{#interfaceOnly}}{{>apiInterface}}{{/interfaceOnly}}{{^interfaceOnly}}{{>apiMethod}}{{/interfaceOnly}}
+    {{/operation}}
+    }
+{{/operations}}

--- a/apiInterface.mustache
+++ b/apiInterface.mustache
@@ -1,0 +1,15 @@
+    @{{httpMethod}}{{#subresourceOperation}}
+    @Path("{{{path}}}"){{/subresourceOperation}}{{#hasConsumes}}
+    @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
+    @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}{{#useSwaggerAnnotations}}
+    @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}"{{#hasAuthMethods}}, authorizations = {
+    {{#authMethods}}{{#isOAuth}}@Authorization(value = "{{name}}", scopes = {
+    {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{^-last}},
+    {{/-last}}{{/scopes}} }){{^-last}},{{/-last}}{{/isOAuth}}
+    {{^isOAuth}}@Authorization(value = "{{name}}"){{^-last}},{{/-last}}
+    {{/isOAuth}}{{/authMethods}} }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-tags}} })
+    @ApiResponses(value = { {{#responses}}
+        @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#returnContainer}}, responseContainer = "{{{.}}}"{{/returnContainer}}){{^-last}},{{/-last}}{{/responses}} }){{/useSwaggerAnnotations}}
+    default {{#supportAsync}}{{>returnAsyncTypeInterface}}{{/supportAsync}}{{^supportAsync}}{{#returnResponse}}Response{{/returnResponse}}{{^returnResponse}}{{>returnTypeInterface}}{{/returnResponse}}{{/supportAsync}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}}) {
+        throw new NotImplementedYetException();
+    }


### PR DESCRIPTION
Instead of just creating empty interface method stubs, this instead changes those to `default` methods which throw `org.jboss.resteasy.spi.NotImplementedYetException`.

**BEFORE**:
```java
import com.siriusxm.clms.models.Errors;

import javax.ws.rs.*;
import javax.ws.rs.core.Response;
import org.jboss.resteasy.spi.NotImplementedYetException;

import java.io.InputStream;
import java.util.Map;
import java.util.List;
import javax.validation.constraints.*;
import javax.validation.Valid;

@Path("/health")
@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", date = "2022-01-19T08:58:06.432122-05:00[America/Kentucky/Louisville]")
public interface SystemApi {

    @GET
    @Produces({ "application/json" })
    Errors checkHealth();
}
```

**AFTER**:
```java
import com.siriusxm.clms.models.Errors;

import javax.ws.rs.*;
import javax.ws.rs.core.Response;
import org.jboss.resteasy.spi.NotImplementedYetException;

import java.io.InputStream;
import java.util.Map;
import java.util.List;
import javax.validation.constraints.*;
import javax.validation.Valid;

@Path("/health")
@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", date = "2022-01-19T08:58:06.432122-05:00[America/Kentucky/Louisville]")
public interface SystemApi {

    @GET
    @Produces({ "application/json" })
    default Errors checkHealth() {
        throw new NotImplementedYetException();
    }
}
```